### PR TITLE
fix issue where quote draws over other elements on small screens (like a phone)

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 
       #quote {
         bottom: 0;
-        position: absolute;
+        position: relative;
       }
     </style>
   </head>


### PR DESCRIPTION
change position of #quote ID selector to relative

This will make the quote render below everything else instead of at the bottom of the screen which may be over other content depending on the screen size.

Alternatively, we could just delete the #quote ID selector but I thought we might want to use it for something else.

This has been bothering me about the site for a long time since it makes it hard to read on my phone which is where I normally view it to get some good Clay quotes and maybe posting a screenshot to the squad.